### PR TITLE
Removing empty_alt_ignore and allow_hash_href

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -17,6 +17,4 @@ URL_IGNORE=cdn.jsdelivr.net
 bundle exec htmlproofer $DEST \
   --disable-external \
   --check-html \
-  --empty_alt_ignore \
-  --allow_hash_href \
   --url_ignore $URL_IGNORE


### PR DESCRIPTION
They do not exist in version 4.4.3