### PR TITLE
Changed docs.microsoft.com to learn.microsoft.com

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://learn.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
 

--- a/_posts/2020-11-10-deep-dive-into-site-isolation-part-1.md
+++ b/_posts/2020-11-10-deep-dive-into-site-isolation-part-1.md
@@ -117,11 +117,11 @@ X-Content-Type-Options: nosniff
 ```
 CORB should block such a cross-origin subresource, and therefore if the subresource was correctly loaded, that indicates a CORB bypass.
 
-If you have an idea where subresources can't be loaded (e.g. [CORB bypass](#corb-bypasses) via WebSocket above), try using [WinDbg](https://www.chromium.org/developers/how-tos/debugging-on-windows/windbg-help)'s [_!address_](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/-address#:~:text=Quotes%20in%20the%20command,for%20the%20string%20%22pad%22) command to find if the string you are looking for has actually entered into the renderer process by searching that string in a heap.
+If you have an idea where subresources can't be loaded (e.g. [CORB bypass](#corb-bypasses) via WebSocket above), try using [WinDbg](https://www.chromium.org/developers/how-tos/debugging-on-windows/windbg-help)'s [_!address_](https://learn.microsoft.com/windows-hardware/drivers/debugger/-address#:~:text=Quotes%20in%20the%20command,for%20the%20string%20%22pad%22) command to find if the string you are looking for has actually entered into the renderer process by searching that string in a heap.
 ```
 !address /f:Heap /c:"s -a %1 %2 \"secret\"" 
 ```
-This searches string _**secret**_ in heap memory of the renderer process. If you are looking for a unicode string instead of an ascii string, you can change _-a_ to _-u_ (more details in the [search memory](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/s--search-memory-) section).
+This searches string _**secret**_ in heap memory of the renderer process. If you are looking for a unicode string instead of an ascii string, you can change _-a_ to _-u_ (more details in the [search memory](https://learn.microsoft.com/windows-hardware/drivers/debugger/s--search-memory-) section).
 
 # What’s next?
 With Site Isolation, CORB, and CORP, we can mitigate many attacks from UXSS to Spectre along with many other client-side attacks, which allow an attacker to read cross-site information. However, there are attacks which can fully compromise a renderer process. The next part will focus on how Site Isolation was further tightened to mitigate such an attacker from obtaining cross-site information.

--- a/_posts/2020-12-28-deep-dive-into-site-isolation-part-2.md
+++ b/_posts/2020-12-28-deep-dive-into-site-isolation-part-2.md
@@ -72,7 +72,7 @@ With these bypasses, an attacker can bypass Site Isolation with the following st
 [This bug](https://bugs.chromium.org/p/chromium/issues/detail?id=971917) was fixed by adding appropriate checks in the browser process.
 
 # Finding bugs in Reader mode through a security review
-When Edge started building the [Reading View](https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/browser-features/reading-view) experience, we decided to use [DOM Distiller](https://chromium.googlesource.com/chromium/dom-distiller#dom-distiller) which powers Reader mode in Chrome. I was curious about how DOM Distiller is implemented, so I started testing it.
+When Edge started building the [Reading View](https://learn.microsoft.com/microsoft-edge/dev-guide/browser-features/reading-view) experience, we decided to use [DOM Distiller](https://chromium.googlesource.com/chromium/dom-distiller#dom-distiller) which powers Reader mode in Chrome. I was curious about how DOM Distiller is implemented, so I started testing it.
 
 Reader mode sanitizes HTML content from the site before rendering for good reading experience. While they tried to remove most of the dangerous tags (e.g. `script`, `style`, etc) many event handlers weren't properly sanitized (e.g. `<button onclick="alert(1)">`). And images and videos from the site could be rendered by design.
 

--- a/_posts/2021-10-11-bug-bounty-hunter-to-working-at-microsoft.md
+++ b/_posts/2021-10-11-bug-bounty-hunter-to-working-at-microsoft.md
@@ -290,7 +290,7 @@ Browser bugs can be generally boiled down to two main types:
        `C:\Users\test\AppData\Local\Google\Chrome\User Data\Crashpad\reports`
        (for Chrome)
     2. Get
-       [windbg](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools)
+       [windbg](https://learn.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools)
        and open those crash dumps and just execute `!analyze -v`
     3. You can also get Chromium
        [ASAN](https://commondatastorage.googleapis.com/chromium-browser-asan/index.html)

--- a/_posts/2022-02-16-Introducing-Enhanced-Security-for-Microsoft-Edge.md
+++ b/_posts/2022-02-16-Introducing-Enhanced-Security-for-Microsoft-Edge.md
@@ -37,10 +37,10 @@ to protect return addresses. Moreover, we are quite excited that Microsoft Edge
 now supports both forwards and backwards control-flow protection. By applying
 these protections, we can provide defense in depth that spans beyond JIT attacks.
 
-[cig]: https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/exploit-protection-reference?view=o365-worldwide#code-integrity-guard
-[cfg]: https://docs.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
+[cig]: https://learn.microsoft.com/microsoft-365/security/defender-endpoint/exploit-protection-reference?view=o365-worldwide#code-integrity-guard
+[cfg]: https://learn.microsoft.com/windows/win32/secbp/control-flow-guard
 [cet]: https://www.intel.com/content/www/us/en/developer/articles/technical/technical-look-control-flow-enforcement-technology.html
-[acg]: https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/exploit-protection-reference?view=o365-worldwide#arbitrary-code-guard
+[acg]: https://learn.microsoft.com/microsoft-365/security/defender-endpoint/exploit-protection-reference?view=o365-worldwide#arbitrary-code-guard
 
 ## Manual and Automatic Site bypass lists
 
@@ -79,7 +79,7 @@ enhancing your security on the web through its options to control this feature
 in the [documentation to Browse more safely with Microsoft
 Edge][documentation].
 
-[documentation]: https://docs.microsoft.com/en-us/DeployEdge/microsoft-edge-security-browse-safer
+[documentation]: https://learn.microsoft.com/DeployEdge/microsoft-edge-security-browse-safer
 
 ## Linux and Mac Support
 

--- a/_posts/2022-05-10-memory-corruption-vulnerabilities-in-edge.md
+++ b/_posts/2022-05-10-memory-corruption-vulnerabilities-in-edge.md
@@ -425,7 +425,7 @@ as an example.
 
 [asan-binaries]: https://chromium.googlesource.com/chromium/src/+/HEAD/docs/asan.md#pre_built-chrome-binaries
 [ghidra]: https://ghidra-sre.org/
-[windbg]: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools
+[windbg]: https://learn.microsoft.com/windows-hardware/drivers/debugger/debugger-download-tools
 
 ## Ghidra setup
 
@@ -611,7 +611,7 @@ debugging for any of the issues listed here, I did use it to investigate some
 more recent issues and it was essential in those cases. So, if you're using
 WinDbg to investigate an issue you've found, it's something to keep in mind.
 
-[time-travel-debugging]: https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/time-travel-debugging-overview
+[time-travel-debugging]: https://learn.microsoft.com/windows-hardware/drivers/debugger/time-travel-debugging-overview
 
 # Conclusion
 

--- a/_posts/2022-6-10-a-story-of-a-bug-found-fuzzing.md
+++ b/_posts/2022-6-10-a-story-of-a-bug-found-fuzzing.md
@@ -249,7 +249,7 @@ see it [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1276331).
 The bug is due to `unmodifiedText` (line 11 in the last screenshot) was handled
 in the browser process without taking account of null termination which lead to
 a
-[heap buffer overflow](https://docs.microsoft.com/en-us/cpp/sanitizers/error-heap-buffer-overflow?view=msvc-170#example---classic-heap-buffer-overflow)
+[heap buffer overflow](https://learn.microsoft.com/cpp/sanitizers/error-heap-buffer-overflow?view=msvc-170#example---classic-heap-buffer-overflow)
 (read), as [caseq@](https://bugs.chromium.org/u/2585305731/) (assigned to this
 bug) mentions: “…That said, this may lead to us sending a piece of browser
 memory into renderer.”


### PR DESCRIPTION
URLs update/cleanup as part of a sweep of MicrosoftEdge org repo's:
* Changed docs.microsoft.com to learn.microsoft.com and removed en-us.

No other changes.